### PR TITLE
DGBase properly solves optional deref bug

### DIFF
--- a/src/core/pdg/include/DGBase.hpp
+++ b/src/core/pdg/include/DGBase.hpp
@@ -311,8 +311,10 @@ namespace llvm {
       if (edge->isRemovableDependence() &&
           (subEdges.size() == 1 || this->isRemovableDependence())) {
         isRemovable = true;
-        for (auto &r : *(edge->getRemedies()))
-          remeds->insert(r);
+        if (auto optional_remeds = edge->getRemedies()){
+          for (auto &r : *(optional_remeds))
+            this->addRemedies(r);
+        }
       } else {
         remeds = nullptr;
         isRemovable = false;


### PR DESCRIPTION
The original code has a bug - deref a dangling pointer - that will lead to undefined behavior.

Minimal example: https://godbolt.org/z/KcxKe3
