### PR TITLE
Add ability to dump Loop PDG after SCAF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
+.clangd
+install
+build
+compile_commands.json
+external/svf
+external/scaf
+external/patch.tar
 # dependencies
 threadpool

--- a/src/core/pdg/include/DGGraphTraits.hpp
+++ b/src/core/pdg/include/DGGraphTraits.hpp
@@ -146,6 +146,7 @@ namespace llvm {
         std::string attrsStr;
         raw_string_ostream ros(attrsStr);
         ros << (edge->isControlDependence() ? cntColor : (edge->isMemoryDependence() ? memColor : varColor));
+        if (edge->isLoopCarriedDependence()) ros << ", penwidth=2";
         if (dg->isExternal(edge->getOutgoingT()) || dg->isExternal(edge->getIncomingT())) ros << ",style=dotted";
         return ros.str();
       }

--- a/src/tools/pdg_stats/src/PDGStats.cpp
+++ b/src/tools/pdg_stats/src/PDGStats.cpp
@@ -8,9 +8,12 @@
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
  * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+#include "PDGPrinter.hpp"
 #include "SystemHeaders.hpp"
 #include "PDGStats.hpp"
 #include "Noelle.hpp"
+#include "llvm/Support/raw_ostream.h"
+#include <string>
 
 using namespace llvm;
 using namespace llvm::noelle;
@@ -74,6 +77,11 @@ bool PDGStats::runOnModule(Module &M) {
     this->collectStatsForNodes(F);
     this->collectStatsForPotentialEdges(programLoopForests, F);
     this->collectStatsForLoopEdges(noelle, programLoopForests, lsToLDI, F);
+
+    if (this->dumpLoopDG) {
+      this->printRefinedLoopGraphsForFunction(noelle, programLoopForests, lsToLDI, F);
+    }
+      
   }
 
   /*
@@ -159,6 +167,50 @@ void PDGStats::collectStatsForPotentialEdges (std::unordered_map<Function *, Sta
 
   return ;
 }
+
+void PDGStats::printRefinedLoopGraphsForFunction(
+  Noelle &noelle, 
+  std::unordered_map<Function *, StayConnectedNestedLoopForest *> &programLoops, 
+  std::unordered_map<LoopStructure *, LoopDependenceInfo *> &lsToLDI,
+  Function &F
+  ){
+  auto loopCount = 0;
+  /*
+   * Check every loop of the program.
+   */
+  for (auto funcLoops : programLoops){
+    auto loopForest = funcLoops.second;
+    for (auto loopTree : loopForest->getTrees()){
+      auto visitor = [this, &lsToLDI, &loopCount, &F](StayConnectedNestedLoopForestNode *n, uint32_t level) -> bool {
+
+        /*
+         * Fetch the loop.
+         */
+        auto currentLoop = n->getLoop();
+        auto currentLDI = lsToLDI[currentLoop];
+        assert(currentLDI != nullptr);
+
+        /*
+         * Fetch the loop dependence graph.
+         */
+        auto loopDG = currentLDI->getLoopDG();
+
+        std::string filename;
+        raw_string_ostream ros(filename);
+        ros << "pdg-function-" << F.getName() << "-loop" << loopCount << "-refined.dot";
+        DGPrinter::writeClusteredGraph<PDG, Value>(ros.str(), loopDG);
+
+        loopCount++;
+
+        return false;
+      };
+      loopTree->visitPreOrder(visitor);
+    }
+  }
+
+  return;
+}
+
 
 void PDGStats::collectStatsForLoopEdges (
   Noelle &noelle, 

--- a/src/tools/pdg_stats/src/PDGStats.hpp
+++ b/src/tools/pdg_stats/src/PDGStats.hpp
@@ -33,6 +33,7 @@ namespace llvm::noelle {
       bool runOnModule(Module &M) override;
     
     private:
+      bool dumpLoopDG = false;
       int64_t numberOfNodes = 0;
       int64_t numberOfEdges = 0;
       int64_t numberOfVariableDependence = 0;
@@ -43,6 +44,13 @@ namespace llvm::noelle {
 
       void collectStatsForNodes(Function &F);
       void collectStatsForPotentialEdges (std::unordered_map<Function *, StayConnectedNestedLoopForest *> &programLoops, Function &F) ;
+
+      void printRefinedLoopGraphsForFunction(
+          Noelle &noelle, 
+          std::unordered_map<Function *, StayConnectedNestedLoopForest *> &programLoops, 
+          std::unordered_map<LoopStructure *, LoopDependenceInfo *> &lsToLDI,
+          Function &F
+          );
 
       void collectStatsForLoopEdges (
         Noelle &noelle, 

--- a/src/tools/pdg_stats/src/Pass.cpp
+++ b/src/tools/pdg_stats/src/Pass.cpp
@@ -15,7 +15,10 @@
 using namespace llvm;
 using namespace llvm::noelle;
 
+static cl::opt<bool> LoopDGDump("noelle-refined-loopdg-dump", cl::ZeroOrMore, cl::Hidden, cl::desc("Dump the refined Loop DG"));
+
 bool PDGStats::doInitialization(Module &M) {
+  this->dumpLoopDG = LoopDGDump;
   return false;
 }
 


### PR DESCRIPTION
- Added a new option to dump loop PDG after refined with SCAF
- Make LC deps thicker in the generated dot file
- Added some files into gitignore for better development
