### PR TITLE
BUG FIX: Identifying wrong instructions as invariants in LICM pass

### DIFF
--- a/src/core/pdg/src/PDGAnalysis_memory.cpp
+++ b/src/core/pdg/src/PDGAnalysis_memory.cpp
@@ -412,6 +412,7 @@ void PDGAnalysis::addEdgeFromFunctionModRef (PDG *pdg, Function &F, AAResults &A
   } else if (makeModRefEdge) {
     pdg->addEdge((Value*)call, (Value*)otherCall)->setMemMustType(true, false, DG_DATA_WAR);
     pdg->addEdge((Value*)call, (Value*)otherCall)->setMemMustType(true, false, DG_DATA_WAW);
+    pdg->addEdge((Value*)call, (Value*)otherCall)->setMemMustType(true, false, DG_DATA_RAW);
   }
 
   return ;

--- a/src/core/pdg/src/PDGAnalysis_memory.cpp
+++ b/src/core/pdg/src/PDGAnalysis_memory.cpp
@@ -73,7 +73,7 @@ void PDGAnalysis::iterateInstForLoad (PDG *pdg, Function &F, AAResults &AA, Data
       if (!this->isActualCode(call)){
         continue ;
       }
-      addEdgeFromFunctionModRef(pdg, F, AA, call, load, false);
+      addEdgeFromFunctionModRef(pdg, F, AA, call, load, true);
       continue ;
     }
   }


### PR DESCRIPTION
 Adding RAW dependency edge conservatively since WAW and WAR are
 eventually disproved by SCAF. SCAF identifies this dependency to be
 RAW. So conservatively adding RAW edge at the time of construction of
 PDG