### PR TITLE
Regression test case for RAW dependency between two call instructions

### DIFF
--- a/tests/regression/RAWCallToCall/test.cpp
+++ b/tests/regression/RAWCallToCall/test.cpp
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <string.h>
+#include <cassert>
 
 typedef struct Point{
   int x;
@@ -51,12 +52,20 @@ int main (int argc, char *argv[]){
     return -1;
   }
 
-  float tinySCCValue = 7;
+  int result = 0;
   for (auto i=0;i < iterations; i++){
     memcpy(p, ptrArr->pointArr[i], sizeof(Point));
-    tinySCCValue += SqrtOfSum(&indirectRef);
+    result += SqrtOfSum(&indirectRef);
   }
 
-  printf("%.2f\n", tinySCCValue);
+  int actualResult = 0;
+  for (auto i=0;i < iterations; i++){
+    p->x = ptrArr->pointArr[i]->x;
+    p->y = ptrArr->pointArr[i]->y;
+    actualResult += SqrtOfSum(&indirectRef);
+  }
+
+  assert(result == actualResult && "results do not match");
+  printf("%d\n", result);
   return 0;
 }

--- a/tests/regression/RAWCallToCall/test.cpp
+++ b/tests/regression/RAWCallToCall/test.cpp
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <string.h>
+
+typedef struct Point{
+  int x;
+  int y;
+  int arr[10];
+} Point;
+
+typedef struct PointArr{
+    int p;
+    int q;
+  Point **pointArr;
+} PointArr;
+
+typedef struct IndirecRefToPoint {
+    Point *p;
+} IndirecRefToPoint;
+
+int __attribute__((noinline)) SqrtOfSum(IndirecRefToPoint *indirectRef){
+  Point *p = indirectRef->p;
+  return sqrt(p->x + p->y);
+}
+
+
+
+int main (int argc, char *argv[]){
+  if (argc < 1){
+    fprintf(stderr, "USAGE: %s LOOP_ITERATIONS\n", argv[0]);
+    return -1;
+  }
+  IndirecRefToPoint indirectRef;
+  PointArr *ptrArr;
+  ptrArr = (PointArr*)malloc(sizeof(PointArr));
+  Point *p = (Point *)malloc(sizeof(Point));
+  indirectRef.p = p;
+  auto iterations = atoi(argv[1]);
+  auto x = atoi(argv[2]);
+  auto y = atoi(argv[3]);
+  ptrArr->pointArr = (Point**)malloc(sizeof(void *)*iterations);
+  for (auto i=0;i < iterations; i++){
+    Point *tmp = (Point *)malloc(sizeof(Point));
+    tmp->x = x++;
+    tmp->y = y++;
+    ptrArr->pointArr[i] = tmp;
+  }
+  if (iterations < 0) {
+    fprintf(stderr, "USAGE: %s requires a position iteration count\n", argv[0]);
+    return -1;
+  }
+
+  float tinySCCValue = 7;
+  for (auto i=0;i < iterations; i++){
+    memcpy(p, ptrArr->pointArr[i], sizeof(Point));
+    tinySCCValue += SqrtOfSum(&indirectRef);
+  }
+
+  printf("%.2f\n", tinySCCValue);
+  return 0;
+}


### PR DESCRIPTION
Adding a test cases which would test for RAW dependency inserted
between two call instructions in a tight loop within the same
basic block. In case the dependency is not inserted then
two calls are treated as loop invariants and moved out of loop.
This would result in wrong output for the parallelized version
of code.