### PR TITLE
Add an optional edge->id map to DGbase

### DIFF
--- a/src/core/pdg/include/noelle/core/DGBase.hpp
+++ b/src/core/pdg/include/noelle/core/DGBase.hpp
@@ -44,7 +44,7 @@ namespace llvm::noelle {
 
       typedef typename std::set<DGEdge<T> *>::iterator edges_iterator;
       typedef typename std::set<DGEdge<T> *>::const_iterator edges_const_iterator;
-      typedef map<DGEdge<T> *, unsigned> DepIdReverseMap_t;
+      typedef map<DGEdge<T> *, uint32_t> DepIdReverseMap_t;
 
       typedef typename std::map<T *, DGNode<T> *>::iterator node_map_iterator;
 
@@ -154,11 +154,11 @@ namespace llvm::noelle {
       /*
        * Deal with the id for each edge and the corresponding map for debugging
        */
-      int getEdgeId(DGEdge<T> *edge) {
+      optional<uint32_t> getEdgeID(DGEdge<T> *edge) {
         if (depLookupMap && depLookupMap->find(edge) != depLookupMap->end())
           return depLookupMap->at(edge);
         else
-          return -1;
+          return std::nullopt;
       }
 
       void setDepLookupMap(shared_ptr<DepIdReverseMap_t> depLookupMap) {

--- a/src/core/pdg/include/noelle/core/DGBase.hpp
+++ b/src/core/pdg/include/noelle/core/DGBase.hpp
@@ -44,6 +44,7 @@ namespace llvm::noelle {
 
       typedef typename std::set<DGEdge<T> *>::iterator edges_iterator;
       typedef typename std::set<DGEdge<T> *>::const_iterator edges_const_iterator;
+      typedef map<DGEdge<T> *, unsigned> DepIdReverseMap_t;
 
       typedef typename std::map<T *, DGNode<T> *>::iterator node_map_iterator;
 
@@ -151,6 +152,20 @@ namespace llvm::noelle {
       DGEdge<T> *copyAddEdge(DGEdge<T> &edgeToCopy);
 
       /*
+       * Deal with the id for each edge and the corresponding map for debugging
+       */
+      int getEdgeId(DGEdge<T> *edge) {
+        if (depLookupMap && depLookupMap->find(edge) != depLookupMap->end())
+          return depLookupMap->at(edge);
+        else
+          return -1;
+      }
+
+      void setDepLookupMap(shared_ptr<DepIdReverseMap_t> depLookupMap) {
+        this->depLookupMap = depLookupMap;
+      }
+
+      /*
        * Merging/Extracting Graphs
        */
       std::unordered_set<DGNode<T> *> getTopLevelNodes(bool onlyInternal = false);
@@ -172,6 +187,7 @@ namespace llvm::noelle {
       DGNode<T> *entryNode;
       std::map<T *, DGNode<T> *> internalNodeMap;
       std::map<T *, DGNode<T> *> externalNodeMap;
+      shared_ptr<DepIdReverseMap_t> depLookupMap = nullptr;
   };
 
   template <class T>

--- a/src/core/pdg/include/noelle/core/DGGraphTraits.hpp
+++ b/src/core/pdg/include/noelle/core/DGGraphTraits.hpp
@@ -149,9 +149,8 @@ namespace llvm {
         if (edge->isLoopCarriedDependence()) ros << ", penwidth=2";
         if (dg->isExternal(edge->getOutgoingT()) || dg->isExternal(edge->getIncomingT())) ros << ",style=dotted";
         // dump the edge id set by the map
-        int edgeId = dg->getEdgeId(edge);
-        if (edgeId != -1) {
-          ros << ",label=" << edgeId;
+        if (auto edgeId = dg->getEdgeID(edge)) {
+          ros << ",label=" << *edgeId;
         }
         return ros.str();
       }

--- a/src/core/pdg/include/noelle/core/DGGraphTraits.hpp
+++ b/src/core/pdg/include/noelle/core/DGGraphTraits.hpp
@@ -148,6 +148,11 @@ namespace llvm {
         ros << (edge->isControlDependence() ? cntColor : (edge->isMemoryDependence() ? memColor : varColor));
         if (edge->isLoopCarriedDependence()) ros << ", penwidth=2";
         if (dg->isExternal(edge->getOutgoingT()) || dg->isExternal(edge->getIncomingT())) ros << ",style=dotted";
+        // dump the edge id set by the map
+        int edgeId = dg->getEdgeId(edge);
+        if (edgeId != -1) {
+          ros << ",label=" << edgeId;
+        }
         return ros.str();
       }
     };


### PR DESCRIPTION
Add an edge to id map to the DGBase. Also modified the DGPrinter to print the ID as a label to the edge.

This is used by the repl of CPF to render the PDG with the edge ID, an important feature to visualize and decide which edge to keep.