### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:20.04
+
+RUN apt update \
+    && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y \
+     git \
+     wget \
+     cmake \
+     build-essential \
+     libz-dev \
+     lsb-release \
+     software-properties-common \
+    && apt clean
+
+RUN wget https://apt.llvm.org/llvm.sh \
+    && chmod +x llvm.sh \
+    && ./llvm.sh 9
+
+RUN ln -s /usr/bin/clang-9 /usr/bin/clang \
+    && ln -s /usr/bin/clang++-9 /usr/bin/clang++
+
+RUN git clone https://github.com/scampanoni/noelle.git
+
+WORKDIR /noelle
+
+RUN make
+
+ENTRYPOINT ["/usr/bin/bash"]


### PR DESCRIPTION
Add Dockerfile to enable building using Docker.
Using Docker to setup noelle environment quickly. Install LLVM 9 using official [Automatic installation script](https://apt.llvm.org/).

Build

`$ docker build -t noelle .`

Run

`docker run --rm -it noelle`

Already built image on my Docker Hub. Test it by running:

`docker run --rm -it yunxwang/noelle`

